### PR TITLE
Trim whitespace

### DIFF
--- a/test/fixture/whitespace-expected.js
+++ b/test/fixture/whitespace-expected.js
@@ -1,0 +1,3 @@
+"use strict";
+
+h("div", {}, []);

--- a/test/whitespace.js
+++ b/test/whitespace.js
@@ -1,0 +1,19 @@
+var test = require('tape');
+var babel = require('babel-core');
+var fs = require('fs');
+var b = require('js-beautify');
+
+var expected = fs.readFileSync(__dirname+'/fixture/whitespace-expected.js', 'utf8');
+var code = (
+    '<div>\n</div>'
+);
+
+var compiled = babel.transform(code, {
+  plugins: ['../index'],
+  jsxPragma: 'h'
+}).code;
+
+test('simple-whitespace', function (t) {
+  t.plan(1);
+  t.equal(b(compiled), b(expected));
+});


### PR DESCRIPTION
I am using indentation in my JSX code:

``` jsx
<div>
    <p>foo</p>
</div>
```

Out of the box, Babel ignores this whitespace when transforming JSX:

``` js
React.createElement(
    "div",
    null,
    React.createElement(
        "p",
        null,
        "foo"
    )
);
```

However, this plugin instead honours the whitespace as children:

``` js
h("div", {}, ["\n    ", h("p", {}, ["foo"])]);
```

I have submitted a failing test case for this.